### PR TITLE
Updated domain in history example to diveintohtml5.info

### DIFF
--- a/examples/history/gallery.js
+++ b/examples/history/gallery.js
@@ -5,7 +5,7 @@ function supports_history_api() {
 function swapPhoto(href) {
   var req = new XMLHttpRequest();
   req.open("GET",
-           "http://diveintohtml5.org/examples/history/gallery/" +
+           "http://diveintohtml5.info/examples/history/gallery/" +
              href.split("/").pop(),
            false);
   req.send(null);


### PR DESCRIPTION
The history pushState example forms its own URLs, and doesn't demonstrate what the example is trying to demonstrate when the URL formed returns a 410 response. Interestingly, it demonstrates a nice fallback behaviour.
