### PR TITLE
fixes broken links pointing to diveintomark.org, in detect.html

### DIFF
--- a/detect.html
+++ b/detect.html
@@ -159,7 +159,7 @@ body{counter-reset:h1 2}
 
 <p class="ss" style="width:224px"><img src="i/openclipart.org_johnny_automatic_at_the_theater.png" alt="audience at the theater" width="224" height="334"><br><span id="live-video"></span>
 
-<p>The <code>&lt;video&gt;</code> element is designed to be usable without any detection scripts. You can specify multiple video files, and browsers that support <abbr>HTML5</abbr> video will choose one based on what video formats they support. (See &ldquo;A gentle introduction to video encoding&rdquo; <a href="http://diveintomark.org/archives/2008/12/18/give-part-1-container-formats">part 1: container formats</a> and <a href="http://diveintomark.org/archives/2008/12/19/give-part-2-lossy-video-codecs">part 2: lossy video codecs</a> to learn about different video formats.)
+<p>The <code>&lt;video&gt;</code> element is designed to be usable without any detection scripts. You can specify multiple video files, and browsers that support <abbr>HTML5</abbr> video will choose one based on what video formats they support. (See &ldquo;A gentle introduction to video encoding&rdquo; <a href="http://web.archive.org/web/20110923030208/http://diveintomark.org/archives/2008/12/18/give-part-1-container-formats">part 1: container formats</a> and <a href="http://web.archive.org/web/20110924054843/http://diveintomark.org/archives/2008/12/19/give-part-2-lossy-video-codecs">part 2: lossy video codecs</a> to learn about different video formats.)
 
 <p>Browsers that don&rsquo;t support <abbr>HTML5</abbr> video will ignore the <code>&lt;video&gt;</code> element completely, but you can use this to your advantage and tell them to play video through a third-party plugin instead. Kroc Camen has designed a solution called <a href="http://camendesign.com/code/video_for_everybody">Video for Everybody!</a> that uses <abbr>HTML5</abbr> video where available, but falls back to QuickTime or Flash in older browsers. This solution uses no JavaScript whatsoever, and it works in virtually every browser, including mobile browsers.
 
@@ -211,7 +211,7 @@ body{counter-reset:h1 2}
 
 <pre><code>  var <mark>v</mark> = document.createElement("video");</code></pre>
 
-<p>A &ldquo;video format&rdquo; is really a combination of different things. In technical terms, you&rsquo;re asking the browser whether it can play H.264 Baseline video and AAC LC audio in an MPEG-4 container. (I&rsquo;ll explain what all that means in <a href="video.html">the Video chapter</a>. You might also be interested in reading <a href="http://diveintomark.org/tag/give">A gentle introduction to video encoding</a>.)
+<p>A &ldquo;video format&rdquo; is really a combination of different things. In technical terms, you&rsquo;re asking the browser whether it can play H.264 Baseline video and AAC LC audio in an MPEG-4 container. (I&rsquo;ll explain what all that means in <a href="video.html">the Video chapter</a>. You might also be interested in reading <a href="http://web.archive.org/web/20110902150810/http://diveintomark.org/tag/give">A gentle introduction to video encoding</a>.)
 
 <pre><code>  return v.canPlayType('<mark>video/mp4; codecs="avc1.42E01E, mp4a.40.2"</mark>');</code></pre>
 
@@ -570,7 +570,7 @@ A: Geolocation support is being added to browsers right now, along with support 
 
 <ul>
 <li><a href="http://camendesign.com/code/video_for_everybody">Video for Everybody!</a>
-<li><a href="http://diveintomark.org/tag/give">A gentle introduction to video encoding</a>
+<li><a href="http://web.archive.org/web/20110902150810/http://diveintomark.org/tag/give">A gentle introduction to video encoding</a>
 <li><a href="http://wiki.whatwg.org/wiki/Video_type_parameters">Video type parameters</a>
 <li><a href="everything.html">The All-In-One Almost-Alphabetical No-Bullshit Guide to Detecting Everything</a>
 <li><a href="http://msdn.microsoft.com/en-us/ie/ff468705.aspx">Internet Explorer 9 Guide for Developers</a>


### PR DESCRIPTION
The detect.html (Chapter: 02. Detecting HTML5 Features) has links
pointing to the diveintomark.org domain, which has expired. To fix
this, all links from diveintomark.org were replaced with a
corresponding link of the Internet Archive's snapshot of respective
the page.
