### PR TITLE
Fix broken wearehugh.com URL in example code.

### DIFF
--- a/video.html
+++ b/video.html
@@ -716,7 +716,7 @@ AddType video/webm .webm</code></pre>
     data="flowplayer-3.2.1.swf"&gt;
     &lt;param name="movie" value="flowplayer-3.2.1.swf" /&gt;
     &lt;param name="allowfullscreen" value="true" /&gt;
-    &lt;param name="flashvars" value="config={'clip': {'url': 'http://wearehugh.com/dih5/pr6.mp4', 'autoPlay':false, 'autoBuffering':true}}" /&gt;
+    &lt;param name="flashvars" value="config={'clip': {'url': 'http://diveintohtml5.info/i/pr6.mp4', 'autoPlay':false, 'autoBuffering':true}}" /&gt;
     &lt;p&gt;Download video as &lt;a href="pr6.mp4"&gt;MP4&lt;/a&gt;, &lt;a href="pr6.webm"&gt;WebM&lt;/a&gt;, or &lt;a href="pr6.ogv"&gt;Ogg&lt;/a&gt;.&lt;/p&gt;
   &lt;/object&gt;
 &lt;/video&gt;


### PR DESCRIPTION
Replace broken http://wearehugh.com/dih5/pr6.mp4 URL with working http://diveintohtml5.info/i/pr6.mp4 URL.
